### PR TITLE
remove old package files 

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -4,6 +4,9 @@ set -e
 useradd -m -g wheel -s /bin/sh tester
 echo "tester ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 chown -R tester:wheel /opt/pkgdir
+# remove old package files
+cd /opt/pkgdir
+rm -f *.tar.zst
 # Install makepkg deps
 pacman -Sy
 # Build the package as `tester' user


### PR DESCRIPTION
when having multiple `tar.zst` files in the repo using [entrypoint.sh#L13](https://github.com/claudiodangelis/aur-pkgbuild-tester/blob/master/scripts/entrypoint.sh#L13) can fail.